### PR TITLE
Make the object wrapping generated Kotlin accessors be internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ public final class MyClassTestAccessors {
 The processor-kotlin artifact generates Kotlin extension methods for the class that owns the 
 annotated fields for more idiomatic accessor usage.
 ```kotlin
-object MyClassTestAccessors {
+internal object MyClassTestAccessors {
     fun <T> MyClass.myField(): T
     
     fun <T> MyClass.myField(newValue: T)

--- a/processor-kotlin/src/main/kotlin/testaccessors/internal/AccessorWriter.kt
+++ b/processor-kotlin/src/main/kotlin/testaccessors/internal/AccessorWriter.kt
@@ -6,6 +6,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
@@ -41,6 +42,7 @@ internal class AccessorWriter(
         elementUtils.getPackageOf(enclosingClassElement).qualifiedName.toString(), fileAndObjectName)
         .indent("  ")
     val objectSpecBuilder = TypeSpec.objectBuilder(fileAndObjectName)
+        .addModifiers(KModifier.INTERNAL)
     annotatedElements.flatMap(object : (Element) -> Iterable<FunSpec> {
       override fun invoke(element: Element) =
           element.getAnnotation(RequiresAccessor::class.java).requires.map {


### PR DESCRIPTION
This prevents issues with leaking internal classes.